### PR TITLE
Updating images tags 

### DIFF
--- a/2-BiasMonitoring/resources/model_storage_container.yaml
+++ b/2-BiasMonitoring/resources/model_storage_container.yaml
@@ -30,7 +30,7 @@ spec:
           value:  THEACCESSKEY
         - name: MINIO_SECRET_KEY
           value: THESECRETKEY
-      image: quay.io/trustyai/modelmesh-minio-examples:gauss
+      image: quay.io/trustyai/modelmesh-minio-examples:latest
       name: minio
 ---
 apiVersion: v1

--- a/3-DataDrift/resources/model_storage_container.yaml
+++ b/3-DataDrift/resources/model_storage_container.yaml
@@ -30,7 +30,7 @@ spec:
           value:  THEACCESSKEY
         - name: MINIO_SECRET_KEY
           value: THESECRETKEY
-      image: quay.io/trustyai/modelmesh-minio-examples:gauss
+      image: quay.io/trustyai/modelmesh-minio-examples:latest
       name: minio
 ---
 apiVersion: v1


### PR DESCRIPTION
@RobGeada -- updating tag of `quay.io/trustyai/modelmesh-minio-examples` from `gauss` to `latest` in the following files

- `2-BiasMonitoring/resources/model_storage_container.yaml`
- `3-DataDrift/resources/model_storage_container.yaml`

The image with a new tag has a necessary folder structure, which should allow for a more flexible model deployment in the future

This partly addresses [RHOAIENG-12513](https://issues.redhat.com/browse/RHOAIENG-12513)