### PR TITLE
Replace images to use the trustyai_testing Quay org

### DIFF
--- a/2-BiasMonitoring/kserve-demo/resources/model_storage_container.yaml
+++ b/2-BiasMonitoring/kserve-demo/resources/model_storage_container.yaml
@@ -30,7 +30,7 @@ spec:
           value:  THEACCESSKEY
         - name: MINIO_SECRET_KEY
           value: THESECRETKEY
-      image: quay.io/trustyai/modelmesh-minio-examples:latest
+      image: quay.io/trustyai_testing/modelmesh-minio-examples:latest
       name: minio
 ---
 apiVersion: v1

--- a/2-BiasMonitoring/modelmesh-demo/resources/model_storage_container.yaml
+++ b/2-BiasMonitoring/modelmesh-demo/resources/model_storage_container.yaml
@@ -30,7 +30,7 @@ spec:
           value:  THEACCESSKEY
         - name: MINIO_SECRET_KEY
           value: THESECRETKEY
-      image: quay.io/trustyai/modelmesh-minio-examples:latest
+      image: quay.io/trustyai_testing/modelmesh-minio-examples:latest
       name: minio
 ---
 apiVersion: v1

--- a/3-DataDrift/kserve-demo/resources/model_storage_container.yaml
+++ b/3-DataDrift/kserve-demo/resources/model_storage_container.yaml
@@ -30,7 +30,7 @@ spec:
           value:  THEACCESSKEY
         - name: MINIO_SECRET_KEY
           value: THESECRETKEY
-      image: quay.io/rh-ee-mmisiura/modelmesh-minio-examples:latest
+      image: quay.io/trustyai_testing/modelmesh-minio-examples:latest
       name: minio
 ---
 apiVersion: v1

--- a/3-DataDrift/kserve-demo/resources/odh-mlserver-1.x.yaml
+++ b/3-DataDrift/kserve-demo/resources/odh-mlserver-1.x.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   containers:
     - name: kserve-container
-      image: quay.io/rh-ee-mmisiura/mlserver:1.6.1 
+      image: quay.io/trustyai_testing/mlserver:1.6.1
       env:
         - name: "MLSERVER_MODEL_IMPLEMENTATION"
           value: "{{.Labels.modelClass}}"

--- a/3-DataDrift/modelmesh-demo/resources/model_storage_container.yaml
+++ b/3-DataDrift/modelmesh-demo/resources/model_storage_container.yaml
@@ -30,7 +30,7 @@ spec:
           value:  THEACCESSKEY
         - name: MINIO_SECRET_KEY
           value: THESECRETKEY
-      image: quay.io/trustyai/modelmesh-minio-examples:latest
+      image: quay.io/trustyai_testing/modelmesh-minio-examples:latest
       name: minio
 ---
 apiVersion: v1

--- a/3-DataDrift/modelmesh-demo/resources/odh-mlserver-1.x.yaml
+++ b/3-DataDrift/modelmesh-demo/resources/odh-mlserver-1.x.yaml
@@ -27,7 +27,7 @@ spec:
 
   containers:
     - name: mlserver
-      image: quay.io/rgeada/mlserver:1.3.2 
+      image: quay.io/trustyai_testing/mlserver:1.6.1
       env:
         - name: MLSERVER_MODELS_DIR
           value: "/models/_mlserver_models/"


### PR DESCRIPTION
Some of the images used in the demos were in personal Quay repos, others were outdated. Replace those images with the newer versions stored in [the trustyai_testing quay org](https://quay.io/organization/trustyai_testing)