### PR TITLE
Updated the service account token path in the README file

### DIFF
--- a/3-DataDrift/kserve-demo/README.md
+++ b/3-DataDrift/kserve-demo/README.md
@@ -41,7 +41,7 @@ an instance of the TrustyAI Service.
 Since models deployed via KServe are currently authenticated by leveraging [Authorino](https://github.com/Kuadrant/authorino), it is necessary to install the Authorino Operator and configure it accordingly; refer to this [blog post](https://developers.redhat.com/articles/2024/07/22/protecting-your-models-made-easy-authorino) on how to set up Authorino on Open Data Hub.
 > ✏️ TrustyAI endpoints are authenticated via a Bearer token. To obtain this token, run the following commands:
 > ```shell
-> oc apply -f resources/trustyai_service_account.yaml
+> oc apply -f resources/service_account.yaml
 > export TOKEN=$(oc create token user-one)   
 > ```
 


### PR DESCRIPTION
The file path used to generate the Bearer token appears was not updated . Updated it in the README file for data drift demo.